### PR TITLE
Add documentation framework and checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,4 @@
 # Agent Instructions
 
 All project-related information and guidelines are maintained in the `docs/` directory.
-Consult the files within `docs/` (e.g., `Post Task Checklist.md`, `JSON Formatting.md`) for standards, checklists, and other documentation.
-This documentation structure is intentionally loose and may evolve; files may be added, modified, renamed, or removed over time.
+Consult the `.md` files within `docs/` for standards, checklists, and other documentation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,5 @@
-Consult `docs/JSON Formatting.md` for formatting any JSON file.
+# Agent Instructions
+
+All project-related information and guidelines are maintained in the `docs/` directory.
+Consult the files within `docs/` (e.g., `Post Task Checklist.md`, `JSON Formatting.md`) for standards, checklists, and other documentation.
+This documentation structure is intentionally loose and may evolve; files may be added, modified, renamed, or removed over time.

--- a/docs/JSON Formatting.md
+++ b/docs/JSON Formatting.md
@@ -1,0 +1,20 @@
+# JSON File Standards Framework
+
+Use this document as a starting point for defining JSON file standards for the project. Add or modify sections as needed.
+
+## File Naming
+<!-- Add naming conventions for JSON files -->
+
+## Structure and Formatting
+<!-- Outline structure, indentation, and formatting rules -->
+
+## Field Conventions
+<!-- Provide guidelines for field names, types, and ordering -->
+
+## Examples
+```json
+{
+  "placeholder": true
+}
+```
+<!-- Replace with project-specific examples -->

--- a/docs/Post Task Checklist.md
+++ b/docs/Post Task Checklist.md
@@ -1,0 +1,10 @@
+# Post-Task Checklist
+
+Before finalizing any task, ensure the following items are complete:
+
+- [ ] Follow all relevant instructions in `AGENTS.md` and the `docs/` directory.
+- [ ] Verify that all code, data, and documentation changes are saved.
+- [ ] Run the project's tests and checks.
+- [ ] Update documentation if necessary.
+- [ ] Commit changes with clear messages.
+- [ ] Open a pull request linking any related issues.

--- a/docs/Post Task Checklist.md
+++ b/docs/Post Task Checklist.md
@@ -3,8 +3,4 @@
 Before finalizing any task, ensure the following items are complete:
 
 - [ ] Follow all relevant instructions in `AGENTS.md` and the `docs/` directory.
-- [ ] Verify that all code, data, and documentation changes are saved.
-- [ ] Run the project's tests and checks.
 - [ ] Update documentation if necessary.
-- [ ] Commit changes with clear messages.
-- [ ] Open a pull request linking any related issues.


### PR DESCRIPTION
## Summary
- Generalize `AGENTS.md` to direct contributors to evolving documentation under `docs/`.
- Add post-task checklist to clarify steps for contributors.
- Provide JSON file standards framework for future schema guidelines.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c66b2254bc832ab9e89557cda1a80f